### PR TITLE
FIX: Now playing album art border-radius background bleed fix

### DIFF
--- a/styles/player.css
+++ b/styles/player.css
@@ -284,6 +284,9 @@ div.cover-art-icon {
   .main-coverSlotCollapsed-container {
     margin: 0;
   }
+  .main-coverSlotCollapsed-container button {
+    background: transparent;
+  }
   .main-nowPlayingWidget-coverArt,
   .cover-art,
   .HD9s7U5E1RLSWKpXmrqx,


### PR DESCRIPTION
# What
Fixes the background of the album art button element bleeding out on the corners when there is a border radius of 1px or greater.

## Before
<img width="127" height="64" alt="Before Bleed Fix" src="https://github.com/user-attachments/assets/06c7591f-52ea-410a-9854-fb2405e0ed30" />

## After
<img width="127" height="64" alt="After Bleed Fix" src="https://github.com/user-attachments/assets/e683dfb0-9a8e-42b1-9bfa-f363f9955e0e" />
