### PR TITLE
Fix top margin for album cover in right sidebar and right sidebar transparency

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -617,6 +617,14 @@ div.main-trackList-trackListRow {
   padding-inline: 8px;
 }
 
+.zAvxP9ntNk6SsomFXWUv { /* Fixes top margin for album cover in right sidebar */
+  margin-top: 16px;
+}
+
+.mzBZbIt7NDzzTffimVhn.TjX06ItOHm0J21btzLaj { /* Fixes right sidebar transparency */
+  background: transparent !important;
+}
+
 .W3E0IT3_STcazjTeyOJa /* Header */ {
   position: absolute;
   height: 4rem;


### PR DESCRIPTION
## ✨ Lucid Theme Enhancement ✨

Made this quick pr to try and fix the two issues I opened: [right sidebar album top margin is 0](https://github.com/sanoojes/spicetify-lucid/issues/145) and the [right sidebar is not translucent](https://github.com/sanoojes/spicetify-lucid/issues/165) 😃

Sorry if this is not up to standard/spec for themes, I've literally never done this before 😆
If there are any things you want me to change, or any issues that arise, please tell me! I'm also in your discord as [@ka_iden](https://discordapp.com/users/1051029345738706964), so you can also ping me there :)