### PR TITLE
Fix backdrop blur on Add to Playlist Modal

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -207,7 +207,8 @@
 .wlb3dYO07PZuYfmNfmkS,
 .DquSH3YjnaIIXMZiOvwA,
 .main-contextMenu-menu,
-#context-menu { /* Fix backdrop blur on Add to Playlist Modal */
+#context-menu > form,
+.jHt3xA6ovwVKkMJKqOhO {
   scrollbar-width: thin;
   background: var(--background-base);
   border-radius: 0.75rem;


### PR DESCRIPTION
## ✨ Lucid Theme Enhancement ✨

PR to fix backdrop blur on Add to Playlist Modal (Issue https://github.com/sanoojes/spicetify-lucid/issues/155)

One line fix, working on version 1.2.74.477.g3be53afe 😄
If any issues arise, or this doesn't work on your machine, please message me!

Image of the modal correctly applying blur:
<img width="2560" height="1381" alt="image" src="https://github.com/user-attachments/assets/421f77a3-fd66-46b6-9677-b08c2dd79e6b" />
