### PR TITLE
Fix docked player gap on sides

### DIFF
--- a/styles/player.css
+++ b/styles/player.css
@@ -30,7 +30,10 @@
   left: 50%;
   height: var(--player-height, 80px);
   transform: translate3d(-50%, 0, 0);
-  padding: 0; /* Fix docked player gap on sides */
+  padding: 0;
+}
+.floating .main-nowPlayingBar-container {
+  padding: 0 var(--panel-gap);
 }
 
 .next-playing-card,


### PR DESCRIPTION
## ✨ Lucid Theme Enhancement ✨

PR to fix docked player gap on sides (Issue https://github.com/sanoojes/spicetify-lucid/issues/136), still allows width dimension change (in percentage) and internal padding

Screenshot showing no more gap:
<img width="166" height="226" alt="image" src="https://github.com/user-attachments/assets/ea7836a9-fe8f-4706-aa6a-908a7c96ae1e" />
