### PR TITLE
Change Spotify's fade out of Now Playing Canvas from going to black to going to transparent

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -658,6 +658,17 @@ div.main-trackList-trackListRow {
   padding-top: 4rem;
 }
 
+/* Change Spotify's fade out of Now Playing Canvas from going to black to going to transparent */
+.Of__Db4QgB9osz_mFxhw:before {
+  background: linear-gradient(180deg, hsla(0, 0%, 7%, .63), hsla(0, 0%, 7%, 0) 24.09%, hsla(0, 0%, 7%, 0) 80%, hsla(0, 0%, 7%, 0) 93.25%, hsla(0, 0%, 0%, 0));
+}
+.Of__Db4QgB9osz_mFxhw:after {
+  background: linear-gradient(180deg, hsla(0, 0%, 7%, .63), hsla(0, 0%, 7%, .53) 30%, hsla(0, 0%, 7%, .53) 70%, hsla(0, 0%, 0%, 0) 95%);
+}
+.Of__Db4QgB9osz_mFxhw video {
+  mask-image: linear-gradient(180deg, hsla(0, 0%, 0%, 1), hsla(0, 0%, 0%, 1) 30%, hsla(0, 0%, 0%, 1) 70%, hsla(0, 0%, 0%, 0));
+}
+
 .OemaZktMXaRcYQ5bcfLZ /* Friend Activity - Card Wrapper */ {
   gap: 16px;
 }


### PR DESCRIPTION
## ✨ Lucid Theme Enhancement ✨

Made a PR to change Spotify's fade out of Now Playing Canvas from going to black to going to transparent (Issue https://github.com/sanoojes/spicetify-lucid/issues/164)

I (subjectively) fixed the issue by copying Spotify's linear gradient and changing the end colour and opacity to transparent.
If any issues arise, or this doesn't work on your machine, or you want me to change any values, please message me :D

Heres an image of the canvas:
<img width="2560" height="1381" alt="image" src="https://github.com/user-attachments/assets/83cc27dd-768a-4a7d-bfaf-f9099b2eeecc" />

And an image of the canvas when expanded:
<img width="2560" height="1381" alt="image" src="https://github.com/user-attachments/assets/45b234a6-1ec3-4671-9976-92ad8f18f7a7" />