### PR TITLE
Fixes related music videos card background in right sidebar

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -611,9 +611,12 @@ div.main-trackList-trackListRow {
     border: var(--hover-border);
   }
 }
-.tB3JVNYttFlVC_oYVfjI {
+.tB3JVNYttFlVC_oYVfjI { /* Fixes related music videos card background in right sidebar */
+  background-color: var(--section-background-base) !important;
+  border-radius: var(--section-border-radius) !important;
+  z-index: 1 !important;
   margin-inline: 0;
-  padding-block: 8px;
+  padding-block: 18px;
   padding-inline: 8px;
 }
 


### PR DESCRIPTION
## ✨ Lucid Theme Enhancement ✨

PR to (subjectively) fix the related music videos card background in right sidebar, from having no tinted background to pulling the colour and border radius from the other card's css (Issue https://github.com/sanoojes/spicetify-lucid/issues/175)
If any issues arise, or this doesn't work on your machine, please message me!

Before:
<img width="2560" height="1381" alt="image" src="https://github.com/user-attachments/assets/99e4b44e-6666-4e7b-8cbb-bbf349a47b4d" />

After:
<img width="2560" height="1381" alt="image" src="https://github.com/user-attachments/assets/3c55e32d-7dfa-4329-9719-904a03b05068" />
